### PR TITLE
Use 3 args open in Net::DNS::Resolver::Base

### DIFF
--- a/lib/Net/DNS/Resolver/Base.pm
+++ b/lib/Net/DNS/Resolver/Base.pm
@@ -181,14 +181,14 @@ sub _read_config_file {			## read resolver config file
 	my $self = shift;
 	my $file = shift;
 
-	local *FILE;
-	open( FILE, $file ) or croak "$file: $!";
+	my $fh;
+	open( $fh, '<', $file ) or croak "$file: $!";
 
 	my @nameserver;
 	my @searchlist;
 
 	local $_;
-	while (<FILE>) {
+	while (<$fh>) {
 		s/[;#].*$//;					# strip comments
 
 		/^nameserver/ && do {
@@ -217,7 +217,7 @@ sub _read_config_file {			## read resolver config file
 		};
 	}
 
-	close(FILE);
+	close($fh);
 
 	$self->nameservers(@nameserver) if @nameserver;
 	$self->searchlist(@searchlist)	if @searchlist;


### PR DESCRIPTION
RT #127557

Convert it to a three args open with a regular SV
instead of bare filehandle.

Note: should also consider patching
- Resolver/cygwin.pm
- Resolver/os390.pm

Upstream-URL: https://rt.cpan.org/Ticket/Display.html?id=127557